### PR TITLE
Fix session_tag and window not defined log

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -126,7 +126,7 @@ export class Client {
             }
             opts['maxBodyLength'] = maxBytes;
             formData.append("file", Buffer.from(request.file.content, request.file.encoding ? request.file.encoding : 'hex'));
-            const url = `${this.options.api_base}/upload` + (request.session_tag ? `?session_tag=${request.session_tag}` : '');
+            const url = `${this.options.api_base}/upload` + (request.session_tag ? `?tag=${request.session_tag}` : '');
             const options = {
                 method: 'POST',
                 uri: url,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -219,5 +219,7 @@ try {
   }
 }
 catch (ex) {
-    console.log('window not defined...');
+    if (typeof window !== 'undefined'){
+      console.log('window not defined...');
+    }
 }


### PR DESCRIPTION
Fix the url parameter when queuing Bitcoin files so that files can be associated to folders as expected.

Do not log 'window not defined...' to console if window isn't defined when running sdk in node.js.